### PR TITLE
#344 | Text widget vertical mode fixes

### DIFF
--- a/cogboard-webapp/src/components/widgets/types/TextWidget/index.js
+++ b/cogboard-webapp/src/components/widgets/types/TextWidget/index.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useSize } from 'react-hook-size';
 import { bool, string } from 'prop-types';
 
@@ -31,8 +31,9 @@ const TruncatedText = ({
   if (isVertical && parentDimensions !== null) {
     const { height } = parentDimensions;
     const ModifiedPre = ModifiedWidth(RotatedStyledPre, height);
+    const VerticalText = height ? ModifiedPre : RotatedStyledPre;
 
-    TruncatedPre = OverflowingText(ModifiedPre);
+    TruncatedPre = OverflowingText(VerticalText);
   } else if (singleLine) {
     TruncatedPre = SingleLineText(StyledPre);
   } else {
@@ -43,15 +44,22 @@ const TruncatedText = ({
 };
 
 const TextWidget = ({ text, textSize, isVertical, singleLine }) => {
-  const targetRef = useRef();
+  const targetRef = useRef(null);
   const centerWrapperDimensions = useSize(targetRef);
+  const [dimensions, setDimensions] = useState(null);
+
+  useEffect(() => {
+    if (centerWrapperDimensions.height) {
+      setDimensions(centerWrapperDimensions);
+    }
+  }, [centerWrapperDimensions]);
 
   return (
     <TypographyVariant variant={textSize}>
       <CenterWrapper ref={targetRef} isVertical={isVertical}>
         <TruncatedText
           isVertical={isVertical}
-          parentDimensions={centerWrapperDimensions}
+          parentDimensions={dimensions}
           singleLine={singleLine}
         >
           {text}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above (if possible start with issue number with # prefix) -->
<!--- Example: #123 - Some description -->

<!--- Remember to use appropriate Labels - this will help to group pull requests in release notes -->

## Description

<!--- Describe your changes in detail -->
This PR fixes incorrect rendering of Text widget in vertical mode, which happens right after widget configuration change, before saving and refreshing the page.

### https://github.com/wttech/cogboard/issues/344

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the [code style](https://github.com/wttech/cogboard/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] Automated functional tests have been added or modified to cover my changes (if applicable)
- [ ] I have updated the documentation accordingly.

---

I hereby agree to the terms of the Cogboard Contributor License Agreement.
