### PR TITLE
#356 - Widget | ToDo list - enter key support while adding items

### DIFF
--- a/cogboard-webapp/src/components/widgets/dialogFields/ToDoListinput.js
+++ b/cogboard-webapp/src/components/widgets/dialogFields/ToDoListinput.js
@@ -67,6 +67,13 @@ const ToDoListInput = ({ value, values, onChange }) => {
     resetInput();
   };
 
+  const onInputKeyDown = event => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      onSaveClick();
+    }
+  };
+
   const onClearClick = () => {
     if (!selectedItems) return;
 
@@ -118,6 +125,7 @@ const ToDoListInput = ({ value, values, onChange }) => {
         placeholder="Item Title"
         margin="normal"
         onChange={handleChangeValItemText}
+        onKeyDown={onInputKeyDown}
         value={formValueItemText}
       />
       <StyledFabGroup>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above (if possible start with issue number with # prefix) -->
<!--- Example: #123 - Some description -->

<!--- Remember to use appropriate Labels - this will help to group pull requests in release notes -->

## Description

Currently in edit dialog for ToDo List widget when user is focused on Item Title text field nad hits enter, the dialog closes. This PR changes this behaviour so the enter key simply confirms addition/update of list item.
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#356

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)

<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the [code style](https://github.com/wttech/cogboard/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] Automated functional tests have been added or modified to cover my changes (if applicable)
- [ ] I have updated the documentation accordingly.

---

I hereby agree to the terms of the Cogboard Contributor License Agreement.
