### PR TITLE
Added Split View on Expected and Recived Request body in Service Chec…

### DIFF
--- a/cogboard-webapp/src/components/PopoverWithControls.js
+++ b/cogboard-webapp/src/components/PopoverWithControls.js
@@ -1,12 +1,19 @@
 import React, { useState } from 'react';
 import copy from 'copy-to-clipboard';
-import { CaptionWithPointer, StyledPopoverText } from './styled';
+import {
+  CaptionWithPointer,
+  StyledPopoverText,
+  StyledPopoverTextWrapper,
+  StyledPopoverHeader
+} from './styled';
 import { Button, Popover } from '@material-ui/core';
 
 export const PopoverWithControls = ({
   title,
   titleHover,
   body,
+  bodyMessage,
+  expectedResponseBody,
   withCopy,
   className
 }) => {
@@ -39,7 +46,20 @@ export const PopoverWithControls = ({
       >
         {withCopy ? <Button onClick={copyBody}>Copy</Button> : null}
         <Button onClick={handlePopoverClose}>Close</Button>
-        <StyledPopoverText>{body}</StyledPopoverText>
+        {bodyMessage === 'NO MATCH' ? (
+          <StyledPopoverTextWrapper>
+            <StyledPopoverText>
+              <StyledPopoverHeader>EXPECTED RESPONSE BODY</StyledPopoverHeader>
+              {expectedResponseBody}
+            </StyledPopoverText>
+            <StyledPopoverText>
+              <StyledPopoverHeader>RECIVED RESPONSE BODY</StyledPopoverHeader>
+              {body}
+            </StyledPopoverText>
+          </StyledPopoverTextWrapper>
+        ) : (
+          <StyledPopoverText>{body}</StyledPopoverText>
+        )}
       </Popover>
     </>
   );

--- a/cogboard-webapp/src/components/styled/index.js
+++ b/cogboard-webapp/src/components/styled/index.js
@@ -128,10 +128,27 @@ export const StyledFormControl = styled(FormControl)`
   max-width: 300px;
 `;
 
-export const StyledPopoverText = styled(Typography)`
+export const StyledPopoverText = styled('div')`
   background: ${COLORS.WHITE};
   color: ${COLORS.BLACK};
   padding: 1rem;
+`;
+
+export const StyledPopoverHeader = styled(Typography)`
+  font-size: 1.2rem;
+  margin-bottom: 10px;
+  font-weight: bold;
+  color: ${COLORS.RED};
+  border-bottom: 2px ${COLORS.RED} solid;
+`;
+
+export const StyledPopoverTextWrapper = styled('div')`
+  display: flex;
+  justify-content: space-around;
+
+  & > * {
+    flex-basis: 50%;
+  }
 `;
 
 export const StyledTabs = styled(Tabs)`

--- a/cogboard-webapp/src/components/widgets/types/ServiceCheckWidget.js
+++ b/cogboard-webapp/src/components/widgets/types/ServiceCheckWidget.js
@@ -37,6 +37,8 @@ const ServiceCheckWidget = ({
       <PopoverWithControls
         title={`Response: ${bodyMessage}`}
         body={body}
+        bodyMessage={bodyMessage}
+        expectedResponseBody={expectedResponseBody}
         withCopy={true}
       />
       <WidgetButton href={url}>


### PR DESCRIPTION
# #292 Widget | Service Check - Add diff on expected vs actual body

## Description

Added split view for Request and Expected Response body when Responses do not match.

## Motivation and Context

Thanks to split view user will be able to quickly diagnose what was expected and what was recived.

## Screenshots (if appropriate)
![Capture](https://user-images.githubusercontent.com/61162166/122919733-dcd1f300-d360-11eb-887b-f59d9995be98.PNG)


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the [code style](https://github.com/wttech/cogboard/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] Automated functional tests have been added or modified to cover my changes (if applicable)
- [ ] I have updated the documentation accordingly.

---

I hereby agree to the terms of the Cogboard Contributor License Agreement.
