### PR TITLE
#378 - Log viewer data and header

### DIFF
--- a/cogboard-app/src/main/kotlin/com/cognifide/cogboard/widget/WidgetIndex.kt
+++ b/cogboard-app/src/main/kotlin/com/cognifide/cogboard/widget/WidgetIndex.kt
@@ -20,6 +20,7 @@ import com.cognifide.cogboard.widget.type.WorldClockWidget
 import com.cognifide.cogboard.widget.type.randompicker.RandomPickerWidget
 import com.cognifide.cogboard.widget.type.sonarqube.SonarQubeWidget
 import com.cognifide.cogboard.widget.type.zabbix.ZabbixWidget
+import com.cognifide.cogboard.widget.type.LogViewerWidget
 import io.vertx.core.Vertx
 import io.vertx.core.json.JsonArray
 import io.vertx.core.json.JsonObject
@@ -48,7 +49,8 @@ class WidgetIndex {
                 "Jira Buckets" to JiraBucketsWidget::class.java,
                 "Service Check" to ServiceCheckWidget::class.java,
                 "SonarQube" to SonarQubeWidget::class.java,
-                "White Space" to WhiteSpaceWidget::class.java
+                "White Space" to WhiteSpaceWidget::class.java,
+                "Log Viewer" to LogViewerWidget::class.java,
         )
 
         fun availableWidgets(): JsonArray {

--- a/cogboard-app/src/main/kotlin/com/cognifide/cogboard/widget/type/LogViewerWidget.kt
+++ b/cogboard-app/src/main/kotlin/com/cognifide/cogboard/widget/type/LogViewerWidget.kt
@@ -11,5 +11,18 @@ class LogViewerWidget(
     serv: BoardsConfigService
 ) : BaseWidget(vertx, config, serv) {
 
-    override fun updateState() { }
+    override fun updateState() {
+        updateStateByCopingPropsToContent(PROPS)
+    }
+
+    companion object {
+        val PROPS = setOf(
+            "endpoint",
+            "schedulePeriod",
+            "path",
+            "logLinesField",
+            "logFileSizeField",
+            "logRecordExpirationField"
+        )
+    }
 }

--- a/cogboard-app/src/main/kotlin/com/cognifide/cogboard/widget/type/LogViewerWidget.kt
+++ b/cogboard-app/src/main/kotlin/com/cognifide/cogboard/widget/type/LogViewerWidget.kt
@@ -1,0 +1,15 @@
+package com.cognifide.cogboard.widget.type
+
+import com.cognifide.cogboard.config.service.BoardsConfigService
+import com.cognifide.cogboard.widget.BaseWidget
+import io.vertx.core.Vertx
+import io.vertx.core.json.JsonObject
+
+class LogViewerWidget(
+    vertx: Vertx,
+    config: JsonObject,
+    serv: BoardsConfigService
+) : BaseWidget(vertx, config, serv) {
+
+    override fun updateState() { }
+}

--- a/cogboard-webapp/package-lock.json
+++ b/cogboard-webapp/package-lock.json
@@ -1194,6 +1194,19 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
+    "@date-io/core": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@date-io/core/-/core-1.3.13.tgz",
+      "integrity": "sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA=="
+    },
+    "@date-io/moment": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@date-io/moment/-/moment-1.3.13.tgz",
+      "integrity": "sha512-3kJYusJtQuOIxq6byZlzAHoW/18iExJer9qfRF5DyyzdAk074seTuJfdofjz4RFfTd/Idk8WylOQpWtERqvFuQ==",
+      "requires": {
+        "@date-io/core": "^1.3.13"
+      }
+    },
     "@emotion/cache": {
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -1935,6 +1948,19 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/pickers": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/@material-ui/pickers/-/pickers-3.3.10.tgz",
+      "integrity": "sha512-hS4pxwn1ZGXVkmgD4tpFpaumUaAg2ZzbTrxltfC5yPw4BJV+mGkfnQOB4VpWEYZw2jv65Z0wLwDE/piQiPPZ3w==",
+      "requires": {
+        "@babel/runtime": "^7.6.0",
+        "@date-io/core": "1.x",
+        "@types/styled-jsx": "^2.2.8",
+        "clsx": "^1.0.2",
+        "react-transition-group": "^4.0.0",
+        "rifm": "^0.7.0"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.11.4",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.4.tgz",
@@ -2486,6 +2512,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw=="
+    },
+    "@types/styled-jsx": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@types/styled-jsx/-/styled-jsx-2.2.9.tgz",
+      "integrity": "sha512-W/iTlIkGEyTBGTEvZCey8EgQlQ5l0DwMqi3iOXlLs2kyBwYTXHKEiU6IZ5EwoRwngL8/dGYuzezSup89ttVHLw==",
+      "requires": {
+        "@types/react": "*"
+      }
     },
     "@types/tapable": {
       "version": "1.0.7",
@@ -14218,6 +14252,14 @@
       "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
     },
+    "rifm": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/rifm/-/rifm-0.7.0.tgz",
+      "integrity": "sha512-DSOJTWHD67860I5ojetXdEQRIBvF6YcpNe53j0vn1vp9EUb9N80EiZTxgP+FkDKorWC8PZw052kTF4C1GOivCQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1"
+      }
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -16575,6 +16617,7 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -16592,6 +16635,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -16622,6 +16666,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -16633,6 +16678,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -16682,12 +16728,14 @@
         "is-extendable": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+          "optional": true
         },
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -16696,6 +16744,7 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -16706,6 +16755,7 @@
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -16761,6 +16811,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "optional": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"

--- a/cogboard-webapp/package.json
+++ b/cogboard-webapp/package.json
@@ -3,10 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@date-io/moment": "^1.3.13",
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
     "@material-ui/core": "^4.9.11",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/pickers": "^3.3.10",
     "@reach/router": "^1.3.3",
     "chartist": "^0.11.4",
     "copy-to-clipboard": "^3.3.1",

--- a/cogboard-webapp/src/components/widgets/dialogFields/index.js
+++ b/cogboard-webapp/src/components/widgets/dialogFields/index.js
@@ -564,6 +564,51 @@ const dialogFields = {
     name: 'linkListItems',
     initialValue: [],
     validator: () => array().ensure()
+  },
+  LogLinesField: {
+    component: NumberInput,
+    name: 'logLinesField',
+    label: 'Number of lines to return',
+    initialValue: 1000,
+    min: 1,
+    step: 1,
+    pattern: /\d*/,
+    valueUpdater: transformMinValue(),
+    validator: ({ min, max }) =>
+      number()
+        .min(min, vm.NUMBER_MIN('Lines', min))
+        .max(max, vm.NUMBER_MAX('Lines', max))
+        .required(vm.FIELD_REQUIRED())
+  },
+  LogFileSizeField: {
+    component: NumberInput,
+    name: 'logFileSizeField',
+    label: 'Log file size limit [MB]',
+    initialValue: 50,
+    min: 1,
+    step: 1,
+    pattern: /\d*/,
+    valueUpdater: transformMinValue(),
+    validator: ({ min, max }) =>
+      number()
+        .min(min, vm.NUMBER_MIN('File size [MB]', min))
+        .max(max, vm.NUMBER_MAX('File size [MB]', max))
+        .required(vm.FIELD_REQUIRED())
+  },
+  LogRecordExpirationField: {
+    component: NumberInput,
+    name: 'logRecordExpirationField',
+    label: 'Log record expiration period [days]',
+    initialValue: 5,
+    min: 1,
+    step: 1,
+    pattern: /\d*/,
+    valueUpdater: transformMinValue(),
+    validator: ({ min, max }) =>
+      number()
+        .min(min, vm.NUMBER_MIN('Days', min))
+        .max(max, vm.NUMBER_MAX('Days', max))
+        .required(vm.FIELD_REQUIRED())
   }
 };
 

--- a/cogboard-webapp/src/components/widgets/index.js
+++ b/cogboard-webapp/src/components/widgets/index.js
@@ -15,6 +15,7 @@ import AemBundleInfoWidget from './types/AemBundleInfoWidget';
 import ZabbixWidget from './types/ZabbixWidget';
 import LinkListWidget from './types/LinkListWidget';
 import ToDoListWidget from './types/ToDoListWidget';
+import LogViewerWidget from './types/LogViewerWidget';
 
 const widgetTypes = {
   WhiteSpaceWidget: {
@@ -199,6 +200,14 @@ const widgetTypes = {
   LinkListWidget: {
     component: LinkListWidget,
     dialogFields: ['LinkListItems'],
+    initialStatus: 'NONE'
+  },
+  LogViewerWidget: {
+    component: LogViewerWidget,
+    dialogFields: ['EndpointField', 'SchedulePeriod'],
+    validationConstraints: {
+      SchedulePeriod: { min: 3 }
+    },
     initialStatus: 'NONE'
   }
 };

--- a/cogboard-webapp/src/components/widgets/index.js
+++ b/cogboard-webapp/src/components/widgets/index.js
@@ -204,9 +204,19 @@ const widgetTypes = {
   },
   LogViewerWidget: {
     component: LogViewerWidget,
-    dialogFields: ['EndpointField', 'SchedulePeriod'],
+    dialogFields: [
+      'EndpointField',
+      'SchedulePeriod',
+      'Path',
+      'LogLinesField',
+      'LogFileSizeField',
+      'LogRecordExpirationField'
+    ],
     validationConstraints: {
-      SchedulePeriod: { min: 3 }
+      SchedulePeriod: { min: 3 },
+      LogLinesField: { min: 1, max: 10_000_000 },
+      LogFileSizeField: { min: 1, max: 1024 },
+      LogRecordExpirationField: { min: 1, max: 1000 }
     },
     initialStatus: 'NONE'
   }

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/LogEntry.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/LogEntry.js
@@ -1,42 +1,67 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { string, number, bool, objectOf, oneOfType } from 'prop-types';
 import { AccordionSummary, AccordionDetails } from '@material-ui/core';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { GridSchema, Text, CustomAccordion } from './styled';
 
-export default function LogEntry() {
+export default function LogEntry({
+  type,
+  date,
+  provider,
+  shortMsg,
+  fullMsg,
+  additionalData
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const additionalDataNames = additionalData && Object.keys(additionalData);
+
   return (
-    <CustomAccordion>
-      <AccordionSummary>
+    <CustomAccordion expanded={expanded}>
+      <AccordionSummary
+        onClick={() => setExpanded(!expanded)}
+        expandIcon={expanded && <ExpandMoreIcon />}
+      >
         <GridSchema>
-          <Text>INFO</Text>
-          <Text>2021-04-22 14:08:37</Text>
-          <Text>mongodb.log</Text>
-          <Text>
-            {'Expected corresponding JSX closing tag for <GridSchemaa>.'}
-          </Text>
+          <Text type={type}>{type?.toUpperCase()}</Text>
+          <Text>{date}</Text>
+          <Text>{provider}</Text>
+          <Text>{shortMsg}</Text>
         </GridSchema>
       </AccordionSummary>
       <AccordionDetails>
         <GridSchema>
-          <div></div>
+          <div></div> {/* first column empty */}
           <div>
-            <Text>ID</Text>
-            <Text>Type</Text>
-            <Text>IP address</Text>
-            <Text>Port</Text>
+            {additionalDataNames.map((name, index) => (
+              <Text key={index}>{name}</Text>
+            ))}
           </div>
           <div>
-            <Text>123456</Text>
-            <Text>sys</Text>
-            <Text>127.0.0.1</Text>
-            <Text>27017</Text>
+            {additionalDataNames.map((name, index) => (
+              <Text key={index}>{`${additionalData[name]}`}</Text>
+            ))}
           </div>
-          <Text>
-            {
-              'SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6) SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6) SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6) SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6)'
-            }
-          </Text>
+          <Text>{fullMsg}</Text>
         </GridSchema>
       </AccordionDetails>
     </CustomAccordion>
   );
 }
+
+LogEntry.propTypes = {
+  type: string,
+  date: string.isRequired,
+  provider: string,
+  shortMsg: string,
+  fullMsg: string,
+  additionalData: objectOf(oneOfType([string, number, bool]))
+};
+
+LogEntry.defaultProps = {
+  type: 'info',
+  provider: '',
+  shortMsg: '',
+  fullMsg: '',
+  additionalData: {}
+};

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/LogEntry.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/LogEntry.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { AccordionSummary, AccordionDetails } from '@material-ui/core';
+import { GridSchema, Text, CustomAccordion } from './styled';
+
+export default function LogEntry() {
+  return (
+    <CustomAccordion>
+      <AccordionSummary>
+        <GridSchema>
+          <Text>INFO</Text>
+          <Text>2021-04-22 14:08:37</Text>
+          <Text>mongodb.log</Text>
+          <Text>
+            {'Expected corresponding JSX closing tag for <GridSchemaa>.'}
+          </Text>
+        </GridSchema>
+      </AccordionSummary>
+      <AccordionDetails>
+        <GridSchema>
+          <div></div>
+          <div>
+            <Text>ID</Text>
+            <Text>Type</Text>
+            <Text>IP address</Text>
+            <Text>Port</Text>
+          </div>
+          <div>
+            <Text>123456</Text>
+            <Text>sys</Text>
+            <Text>127.0.0.1</Text>
+            <Text>27017</Text>
+          </div>
+          <Text>
+            {
+              'SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6) SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6) SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6) SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6)'
+            }
+          </Text>
+        </GridSchema>
+      </AccordionDetails>
+    </CustomAccordion>
+  );
+}

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/LogEntry.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/LogEntry.js
@@ -1,20 +1,48 @@
 import React, { useState } from 'react';
-import { string, number, bool, objectOf, oneOfType } from 'prop-types';
+import {
+  string,
+  number,
+  bool,
+  shape,
+  oneOfType,
+  arrayOf,
+  objectOf
+} from 'prop-types';
 import { AccordionSummary, AccordionDetails } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import { GridSchema, Text, CustomAccordion } from './styled';
+import {
+  GridSchema,
+  Text,
+  CustomAccordion,
+  VariableGridSchema
+} from './styled';
+import { getGridTemplate } from './helpers';
 
-export default function LogEntry({
-  type,
-  date,
-  provider,
-  shortMsg,
-  fullMsg,
-  additionalData
-}) {
+export default function LogEntry({ type, date, additionalData, variableData }) {
   const [expanded, setExpanded] = useState(false);
 
-  const additionalDataNames = additionalData && Object.keys(additionalData);
+  const AdditionalData = ({ names }) => {
+    const additionalDataNames = additionalData && Object.keys(additionalData);
+    return (
+      <div>
+        {additionalDataNames.map((name, index) => (
+          <Text key={index}>{names ? name : `${additionalData[name]}`}</Text>
+        ))}
+      </div>
+    );
+  };
+
+  const VariablePart = ({ description }) => {
+    const variableFieldsTemplate = getGridTemplate(variableData.template);
+    const data = description ? variableData.description : variableData.header;
+    return (
+      <VariableGridSchema template={variableFieldsTemplate}>
+        {data.map((text, index) => (
+          <Text key={index}>{text}</Text>
+        ))}
+      </VariableGridSchema>
+    );
+  };
 
   return (
     <CustomAccordion expanded={expanded}>
@@ -25,24 +53,14 @@ export default function LogEntry({
         <GridSchema>
           <Text type={type}>{type?.toUpperCase()}</Text>
           <Text>{date}</Text>
-          <Text>{provider}</Text>
-          <Text>{shortMsg}</Text>
+          <VariablePart />
         </GridSchema>
       </AccordionSummary>
       <AccordionDetails>
         <GridSchema>
-          <div></div> {/* first column empty */}
-          <div>
-            {additionalDataNames.map((name, index) => (
-              <Text key={index}>{name}</Text>
-            ))}
-          </div>
-          <div>
-            {additionalDataNames.map((name, index) => (
-              <Text key={index}>{`${additionalData[name]}`}</Text>
-            ))}
-          </div>
-          <Text>{fullMsg}</Text>
+          <AdditionalData names />
+          <AdditionalData />
+          <VariablePart description />
         </GridSchema>
       </AccordionDetails>
     </CustomAccordion>
@@ -52,16 +70,20 @@ export default function LogEntry({
 LogEntry.propTypes = {
   type: string,
   date: string.isRequired,
-  provider: string,
-  shortMsg: string,
-  fullMsg: string,
-  additionalData: objectOf(oneOfType([string, number, bool]))
+  additionalData: objectOf(oneOfType([string, number, bool])),
+  variableData: shape({
+    template: arrayOf(string).isRequired,
+    header: arrayOf(oneOfType([string, number, bool])).isRequired,
+    description: arrayOf(oneOfType([string, number, bool])).isRequired
+  })
 };
 
 LogEntry.defaultProps = {
   type: 'info',
-  provider: '',
-  shortMsg: '',
-  fullMsg: '',
+  variableData: {
+    template: [],
+    header: [],
+    description: []
+  },
   additionalData: {}
 };

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/helpers.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/helpers.js
@@ -1,0 +1,6 @@
+export const getGridTemplate = columnNames => {
+  const widths = columnNames.map(name =>
+    name.toLowerCase() === 'message' ? '3fr ' : '1fr '
+  );
+  return widths.reduce((acc, current) => acc + current, '');
+};

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js
@@ -8,6 +8,20 @@ import {
   LogsWrapper
 } from './styled';
 
+const testData = {
+  date: '2021-04-22 14:08:37',
+  provider: 'mongodb.log',
+  fullMsg:
+    'SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6) SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6) SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6) SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6)',
+  shortMsg: 'Expected corresponding JSX closing tag for <GridSchemaa>.',
+  additionalData: {
+    ID: '123456',
+    Type: 'sys',
+    'IP address': '127.0.0.1',
+    Port: '27017'
+  }
+};
+
 export default function LogList() {
   return (
     <Container>
@@ -21,16 +35,88 @@ export default function LogList() {
       </Header>
 
       <LogsWrapper>
-        <LogEntry />
-        <LogEntry />
-        <LogEntry />
-        <LogEntry />
-        <LogEntry />
-        <LogEntry />
-        <LogEntry />
-        <LogEntry />
-        <LogEntry />
-        <LogEntry />
+        {/* static presentation */}
+        <LogEntry
+          date={testData.date}
+          provider={testData.provider}
+          shortMsg={testData.shortMsg}
+          fullMsg={testData.fullMsg}
+        />
+        <LogEntry
+          type="INFO"
+          date={testData.date}
+          provider={testData.provider}
+          shortMsg={testData.shortMsg}
+          fullMsg={testData.fullMsg}
+          additionalData={{
+            bool: true,
+            bool2: false,
+            num: 12,
+            num2: 12.5,
+            str: 'smth'
+          }}
+        />
+        <LogEntry
+          type="info"
+          date={testData.date}
+          provider={testData.provider}
+          shortMsg={testData.shortMsg}
+          fullMsg={testData.fullMsg}
+        />
+        <LogEntry
+          type="SUCCESS"
+          date={testData.date}
+          provider={testData.provider}
+          shortMsg={testData.shortMsg}
+          fullMsg={testData.fullMsg}
+          additionalData={testData.additionalData}
+        />
+        <LogEntry
+          type="success"
+          date={testData.date}
+          provider={testData.provider}
+          shortMsg={testData.shortMsg}
+          fullMsg={testData.fullMsg}
+          additionalData={testData.additionalData}
+        />
+        <LogEntry
+          type="ERROR"
+          date={testData.date}
+          provider={testData.provider}
+          shortMsg={testData.shortMsg}
+          fullMsg={testData.fullMsg}
+          additionalData={testData.additionalData}
+        />
+        <LogEntry
+          type="error"
+          date={testData.date}
+          provider={testData.provider}
+          shortMsg={testData.shortMsg}
+          fullMsg={testData.fullMsg}
+          additionalData={testData.additionalData}
+        />
+        <LogEntry
+          type="WARN"
+          date={testData.date}
+          provider={testData.provider}
+          shortMsg={testData.shortMsg}
+          fullMsg={testData.fullMsg}
+          additionalData={testData.additionalData}
+        />
+        <LogEntry
+          type="warn"
+          date={testData.date}
+          provider={testData.provider}
+          shortMsg={testData.shortMsg}
+          fullMsg={testData.fullMsg}
+          additionalData={testData.additionalData}
+        />
+        <LogEntry
+          date={testData.date}
+          provider={testData.provider}
+          shortMsg={testData.shortMsg}
+          fullMsg={testData.fullMsg}
+        />
       </LogsWrapper>
     </Container>
   );

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import LogEntry from './LogEntry';
+import {
+  Container,
+  Header,
+  GridSchema,
+  ColumnTitle,
+  LogsWrapper
+} from './styled';
+
+export default function LogList() {
+  return (
+    <Container>
+      <Header>
+        <GridSchema>
+          <ColumnTitle>Level</ColumnTitle>
+          <ColumnTitle>Date</ColumnTitle>
+          <ColumnTitle>Provider</ColumnTitle>
+          <ColumnTitle>Message</ColumnTitle>
+        </GridSchema>
+      </Header>
+
+      <LogsWrapper>
+        <LogEntry />
+        <LogEntry />
+        <LogEntry />
+        <LogEntry />
+        <LogEntry />
+        <LogEntry />
+        <LogEntry />
+        <LogEntry />
+        <LogEntry />
+        <LogEntry />
+      </LogsWrapper>
+    </Container>
+  );
+}

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js
@@ -5,117 +5,107 @@ import {
   Header,
   GridSchema,
   ColumnTitle,
-  LogsWrapper
+  LogsWrapper,
+  VariableGridSchema
 } from './styled';
+import { getGridTemplate } from './helpers';
 
+const testLogTemplate = ['Provider', 'Message'];
 const testData = {
   date: '2021-04-22 14:08:37',
-  provider: 'mongodb.log',
-  fullMsg:
-    'SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6) SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6) SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6) SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6)',
-  shortMsg: 'Expected corresponding JSX closing tag for <GridSchemaa>.',
   additionalData: {
     ID: '123456',
     Type: 'sys',
     'IP address': '127.0.0.1',
     Port: '27017'
+  },
+  variableData: {
+    template: testLogTemplate,
+    header: [
+      'mongodb.log',
+      'Expected corresponding JSX closing tag for <GridSchemaa>.'
+    ],
+    description: [
+      'provider desc',
+      'SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6) SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6) SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6) SyntaxError: /Users/celmer/Documents/js/cogboard/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/index.js: Expected corresponding JSX closing tag for <GridSchemaa>. (21:6)'
+    ]
   }
 };
 
 export default function LogList() {
+  const VariableLogListHeader = () => (
+    <VariableGridSchema template={getGridTemplate(testLogTemplate)}>
+      {testLogTemplate.map((name, index) => (
+        <ColumnTitle key={index}>{name}</ColumnTitle>
+      ))}
+    </VariableGridSchema>
+  );
+
   return (
     <Container>
       <Header>
         <GridSchema>
           <ColumnTitle>Level</ColumnTitle>
           <ColumnTitle>Date</ColumnTitle>
-          <ColumnTitle>Provider</ColumnTitle>
-          <ColumnTitle>Message</ColumnTitle>
+          <VariableLogListHeader />
         </GridSchema>
       </Header>
 
       <LogsWrapper>
         {/* static presentation */}
         <LogEntry
-          date={testData.date}
-          provider={testData.provider}
-          shortMsg={testData.shortMsg}
-          fullMsg={testData.fullMsg}
-        />
-        <LogEntry
-          type="INFO"
-          date={testData.date}
-          provider={testData.provider}
-          shortMsg={testData.shortMsg}
-          fullMsg={testData.fullMsg}
-          additionalData={{
-            bool: true,
-            bool2: false,
-            num: 12,
-            num2: 12.5,
-            str: 'smth'
-          }}
-        />
-        <LogEntry
           type="info"
           date={testData.date}
-          provider={testData.provider}
-          shortMsg={testData.shortMsg}
-          fullMsg={testData.fullMsg}
-        />
-        <LogEntry
-          type="SUCCESS"
-          date={testData.date}
-          provider={testData.provider}
-          shortMsg={testData.shortMsg}
-          fullMsg={testData.fullMsg}
           additionalData={testData.additionalData}
-        />
-        <LogEntry
-          type="success"
-          date={testData.date}
-          provider={testData.provider}
-          shortMsg={testData.shortMsg}
-          fullMsg={testData.fullMsg}
-          additionalData={testData.additionalData}
-        />
-        <LogEntry
-          type="ERROR"
-          date={testData.date}
-          provider={testData.provider}
-          shortMsg={testData.shortMsg}
-          fullMsg={testData.fullMsg}
-          additionalData={testData.additionalData}
-        />
-        <LogEntry
-          type="error"
-          date={testData.date}
-          provider={testData.provider}
-          shortMsg={testData.shortMsg}
-          fullMsg={testData.fullMsg}
-          additionalData={testData.additionalData}
-        />
-        <LogEntry
-          type="WARN"
-          date={testData.date}
-          provider={testData.provider}
-          shortMsg={testData.shortMsg}
-          fullMsg={testData.fullMsg}
-          additionalData={testData.additionalData}
+          variableData={testData.variableData}
         />
         <LogEntry
           type="warn"
           date={testData.date}
-          provider={testData.provider}
-          shortMsg={testData.shortMsg}
-          fullMsg={testData.fullMsg}
           additionalData={testData.additionalData}
+          variableData={testData.variableData}
+        />
+        <LogEntry
+          type="error"
+          date={testData.date}
+          additionalData={testData.additionalData}
+          variableData={testData.variableData}
+        />
+        <LogEntry
+          type="success"
+          date={testData.date}
+          additionalData={testData.additionalData}
+          variableData={testData.variableData}
         />
         <LogEntry
           date={testData.date}
-          provider={testData.provider}
-          shortMsg={testData.shortMsg}
-          fullMsg={testData.fullMsg}
+          additionalData={testData.additionalData}
+          variableData={testData.variableData}
+        />
+        <LogEntry type="error" date={testData.date} />
+        <LogEntry
+          type="info"
+          date={testData.date}
+          additionalData={testData.additionalData}
+          variableData={testData.variableData}
+        />
+        <LogEntry
+          type="warn"
+          date={testData.date}
+          additionalData={testData.additionalData}
+          variableData={testData.variableData}
+        />
+        <LogEntry
+          type="error"
+          date={testData.date}
+          additionalData={testData.additionalData}
+          variableData={testData.variableData}
+        />
+        <LogEntry
+          type="success"
+          date={testData.date}
+          additionalData={testData.additionalData}
+          variableData={testData.variableData}
         />
       </LogsWrapper>
     </Container>

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/styled.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/styled.js
@@ -1,10 +1,11 @@
 import styled from '@emotion/styled/macro';
+import { COLORS } from '../../../../../constants';
 import { Typography, Accordion } from '@material-ui/core';
 
 export const Container = styled.div`
   max-height: 100%;
   display: grid;
-  padding-top: 20px;
+  padding-top: 76px;
   grid-template-rows: 34px 1fr;
 `;
 
@@ -27,9 +28,24 @@ export const ColumnTitle = styled(Typography)`
   font-size: 0.85rem;
 `;
 
-export const Text = styled(Typography)`
-  font-size: 0.8rem;
-`;
+export const Text = styled(Typography)(props => {
+  const getColor = type =>
+    ({
+      info: COLORS.WHITE,
+      success: COLORS.GREEN,
+      warn: COLORS.YELLOW,
+      error: COLORS.RED
+    }[type.toLowerCase()]);
+
+  return `
+      font-size: 0.8rem;
+      ${props.type &&
+        `
+        font-weight: 500;
+        color: ${getColor(props.type)};
+      `}
+    `;
+});
 
 export const LogsWrapper = styled.div`
   padding: 6px 0;
@@ -52,12 +68,19 @@ export const CustomAccordion = styled(Accordion)`
     min-height: unset;
   }
 
-  .MuiButtonBase-root {
-    padding-left: unset;
-    padding-right: unset;
+  .MuiButtonBase-root .MuiIconButton-root {
+    position: absolute;
+    top: 0;
+    right: 16px;
   }
+
+  .MuiButtonBase-root {
+    padding: unset;
+  }
+
   .MuiAccordionSummary-content {
     margin: 0;
+    padding: 4px 0;
   }
   .MuiAccordionSummary-content.Mui-expanded {
     min-height: unset;

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/styled.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/styled.js
@@ -18,10 +18,18 @@ export const Header = styled.div`
 `;
 
 export const GridSchema = styled.div`
+  width: 100%;
   display: grid;
-  grid-template-columns: 70px 150px 190px 1fr;
+  grid-template-columns: 70px 150px 1fr;
   padding: 0 10px;
 `;
+export const VariableGridSchema = styled.div(
+  props => `
+    width: 100%;
+    display: grid;
+    grid-template-columns: ${props.template};
+  `
+);
 
 export const ColumnTitle = styled(Typography)`
   font-weight: 600;
@@ -38,7 +46,9 @@ export const Text = styled(Typography)(props => {
     }[type.toLowerCase()]);
 
   return `
+      line-height: 19px;
       font-size: 0.8rem;
+      font-weight: 400;
       ${props.type &&
         `
         font-weight: 500;

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/styled.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/styled.js
@@ -1,0 +1,69 @@
+import styled from '@emotion/styled/macro';
+import { Typography, Accordion } from '@material-ui/core';
+
+export const Container = styled.div`
+  max-height: 100%;
+  display: grid;
+  padding-top: 20px;
+  grid-template-rows: 34px 1fr;
+`;
+
+export const Header = styled.div`
+  border-bottom: 1px solid rgba(255, 255, 255, 0.5);
+  border-left: none;
+  border-right: none;
+
+  padding: 6px 0;
+`;
+
+export const GridSchema = styled.div`
+  display: grid;
+  grid-template-columns: 70px 150px 190px 1fr;
+  padding: 0 10px;
+`;
+
+export const ColumnTitle = styled(Typography)`
+  font-weight: 600;
+  font-size: 0.85rem;
+`;
+
+export const Text = styled(Typography)`
+  font-size: 0.8rem;
+`;
+
+export const LogsWrapper = styled.div`
+  padding: 6px 0;
+  overflow-y: auto;
+  height: 100%;
+`;
+
+export const CustomAccordion = styled(Accordion)`
+  margin: 2px 0;
+
+  &.MuiPaper-root {
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+  &.Mui-expanded {
+    margin: 8px 0;
+  }
+
+  .MuiAccordionSummary-root {
+    padding: 4px;
+    min-height: unset;
+  }
+
+  .MuiButtonBase-root {
+    padding-left: unset;
+    padding-right: unset;
+  }
+  .MuiAccordionSummary-content {
+    margin: 0;
+  }
+  .MuiAccordionSummary-content.Mui-expanded {
+    min-height: unset;
+  }
+
+  .MuiAccordionDetails-root {
+    padding: 0 0 4px 0;
+  }
+`;

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/styled.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/LogList/styled.js
@@ -87,6 +87,7 @@ export const CustomAccordion = styled(Accordion)`
   }
 
   .MuiAccordionDetails-root {
-    padding: 0 0 4px 0;
+    padding: 4px 0;
+    background-color: rgba(0, 0, 0, 0.15);
   }
 `;

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/DateRangePicker/index.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/DateRangePicker/index.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import DateFnsUtils from '@date-io/date-fns';
+import ToolbarGroup from '../ToolbarGroup';
+import { MuiPickersUtilsProvider, DateTimePicker } from '@material-ui/pickers';
+
+export default function DateRangePicker() {
+  return (
+    <MuiPickersUtilsProvider utils={DateFnsUtils}>
+      <ToolbarGroup title="Date span">
+        <DateTimePicker />
+        <DateTimePicker />
+      </ToolbarGroup>
+    </MuiPickersUtilsProvider>
+  );
+}

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/DateRangePicker/index.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/DateRangePicker/index.js
@@ -1,15 +1,23 @@
 import React from 'react';
-import DateFnsUtils from '@date-io/date-fns';
-import ToolbarGroup from '../ToolbarGroup';
+import MomentUtils from '@date-io/moment';
 import { MuiPickersUtilsProvider, DateTimePicker } from '@material-ui/pickers';
+import ToolbarGroup from '../ToolbarGroup';
 
 export default function DateRangePicker() {
   return (
-    <MuiPickersUtilsProvider utils={DateFnsUtils}>
-      <ToolbarGroup title="Date span">
-        <DateTimePicker />
-        <DateTimePicker />
-      </ToolbarGroup>
-    </MuiPickersUtilsProvider>
+    <ToolbarGroup title="Date span">
+      <MuiPickersUtilsProvider utils={MomentUtils}>
+        <DateTimePicker
+          label="Begin"
+          format="hh:mm DD/MM/YY"
+          onChange={() => console.log('TODO')}
+        />
+        <DateTimePicker
+          label="End"
+          format="hh:mm DD/MM/YY"
+          onChange={() => console.log('TODO')}
+        />
+      </MuiPickersUtilsProvider>
+    </ToolbarGroup>
   );
 }

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/FilterPicker/index.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/FilterPicker/index.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import {
+  Button,
+  Select,
+  Chip,
+  MenuItem,
+  FormControl,
+  InputLabel
+} from '@material-ui/core';
+import { ScrollableBox } from './styled';
+import ToolbarGroup from '../ToolbarGroup';
+import { useState } from 'react';
+
+export default function FilterPicker() {
+  const handleDelete = name => {
+    setFilters(filters.filter(item => item !== name));
+  };
+
+  const [filters, setFilters] = useState([]);
+  const [logLevel, setLogLevel] = useState('');
+
+  return (
+    <ToolbarGroup title="Filters">
+      <FormControl>
+        <InputLabel id="filters-label">Filters</InputLabel>
+        <Select
+          id="filters"
+          labelId="filters-label"
+          multiple
+          style={{ width: '200px' }}
+          value={filters}
+          size="small"
+          onChange={e => setFilters(e.target.value)}
+          renderValue={selected => (
+            <ScrollableBox>
+              {selected.map(value => (
+                <Chip
+                  key={value}
+                  label={value}
+                  onDelete={e => handleDelete(value)}
+                  onMouseDown={e => {
+                    e.stopPropagation();
+                  }}
+                  style={{ marginRight: '4px' }}
+                  size="small"
+                />
+              ))}
+            </ScrollableBox>
+          )}
+        >
+          <MenuItem value="all">ALL</MenuItem>
+          <MenuItem value="debug">DEBUG</MenuItem>
+          <MenuItem value="info">INFO</MenuItem>
+          <MenuItem value="warn">WARN</MenuItem>
+          <MenuItem value="error">ERROR</MenuItem>
+        </Select>
+      </FormControl>
+
+      <FormControl>
+        <InputLabel id="log-level-label">Log level</InputLabel>
+        <Select
+          labelId="log-level-label"
+          label="Log level"
+          style={{ width: '100px' }}
+          value={logLevel}
+          onChange={e => setLogLevel(e.target.value)}
+        >
+          <MenuItem value="">ALL</MenuItem>
+          <MenuItem value="debug">DEBUG</MenuItem>
+          <MenuItem value="info">INFO</MenuItem>
+          <MenuItem value="warn">WARN</MenuItem>
+          <MenuItem value="error">ERROR</MenuItem>
+        </Select>
+      </FormControl>
+      <Button variant="contained" size="small">
+        Advanced
+      </Button>
+    </ToolbarGroup>
+  );
+}

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/FilterPicker/styled.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/FilterPicker/styled.js
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled/macro';
+import { Box } from '@material-ui/core';
+
+export const ScrollableBox = styled(Box)`
+  overflow-x: scroll;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/SearchInput/index.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/SearchInput/index.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { TextField } from '@material-ui/core';
+import { Wrapper, CustomIconButton } from './styled';
+import SearchIcon from '@material-ui/icons/Search';
+
+export default function SearchInput() {
+  return (
+    <Wrapper>
+      <TextField id="query" label="Search logs..." />
+      <CustomIconButton size="small" variant="contained">
+        <SearchIcon />
+      </CustomIconButton>
+    </Wrapper>
+  );
+}

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/SearchInput/index.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/SearchInput/index.js
@@ -7,7 +7,7 @@ import SearchIcon from '@material-ui/icons/Search';
 export default function SearchInput() {
   return (
     <Wrapper>
-      <TextField id="query" label="Search logs..." />
+      <TextField id="query" label="Search..." />
       <CustomIconButton size="small" variant="contained">
         <SearchIcon />
       </CustomIconButton>

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/SearchInput/styled.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/SearchInput/styled.js
@@ -1,0 +1,14 @@
+import styled from '@emotion/styled/macro';
+import { IconButton } from '@material-ui/core';
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  position: relative;
+`;
+
+export const CustomIconButton = styled(IconButton)`
+  position: absolute;
+  bottom: 0;
+  right: 0;
+`;

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/ToolbarGroup.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/ToolbarGroup.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import styled from '@emotion/styled/macro';
+import { string } from 'prop-types';
+import { Typography } from '@material-ui/core';
+
+const Wrapper = styled.div`
+  display: grid;
+  grid-template-rows: 24px auto;
+`;
+
+const GroupContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: flex-end;
+  gap: 5px;
+`;
+
+export default function ToolbarGroup({ title, children }) {
+  return (
+    <Wrapper>
+      <Typography>{title}</Typography>
+      <GroupContainer>{children}</GroupContainer>
+    </Wrapper>
+  );
+}
+
+ToolbarGroup.propTypes = {
+  title: string
+};

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/index.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/index.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Button, useTheme } from '@material-ui/core';
+import { RedButton, ScrollableDiv } from './styled';
+import SearchInput from './SearchInput';
+import ToolbarGroup from './ToolbarGroup';
+import DateRangePicker from './DateRangePicker';
+import GetAppIcon from '@material-ui/icons/GetApp';
+import DeleteIcon from '@material-ui/icons/Delete';
+import FilterPicker from './FilterPicker';
+
+export default function Toolbar() {
+  const theme = useTheme();
+
+  return (
+    <ScrollableDiv>
+      <ToolbarGroup>
+        <SearchInput />
+      </ToolbarGroup>
+
+      <FilterPicker />
+
+      <DateRangePicker />
+
+      <ToolbarGroup>
+        <Button variant="contained" size="small">
+          <GetAppIcon />
+          Follow logs
+        </Button>
+        <RedButton variant="contained" size="small" theme={theme}>
+          <DeleteIcon />
+          Clear logs
+        </RedButton>
+      </ToolbarGroup>
+    </ScrollableDiv>
+  );
+}

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/index.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button, useTheme } from '@material-ui/core';
-import { RedButton, ScrollableDiv } from './styled';
+import { RedButton, Wrapper } from './styled';
 import SearchInput from './SearchInput';
 import ToolbarGroup from './ToolbarGroup';
 import DateRangePicker from './DateRangePicker';
@@ -12,7 +12,7 @@ export default function Toolbar() {
   const theme = useTheme();
 
   return (
-    <ScrollableDiv>
+    <Wrapper>
       <ToolbarGroup>
         <SearchInput />
       </ToolbarGroup>
@@ -31,6 +31,6 @@ export default function Toolbar() {
           Clear logs
         </RedButton>
       </ToolbarGroup>
-    </ScrollableDiv>
+    </Wrapper>
   );
 }

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/styled.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/styled.js
@@ -6,13 +6,11 @@ export const RedButton = styled(Button)`
   background-color: ${({ theme }) => theme.palette.status.FAIL};
 `;
 
-export const ScrollableDiv = styled.div`
+export const Wrapper = styled.div`
   overflow-x: hidden;
   display: flex;
   flex-direction: row;
-  flex-wrap: wrap;
   align-items: stretch;
   justify-content: space-between;
   gap: 16px;
-  overflow-x: scroll;
 `;

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/styled.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/styled.js
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled/macro';
+import { Button } from '@material-ui/core';
+
+export const RedButton = styled(Button)`
+  color: white;
+  background-color: ${({ theme }) => theme.palette.status.FAIL};
+`;
+
+export const ScrollableDiv = styled.div`
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: stretch;
+  justify-content: space-between;
+  gap: 16px;
+  overflow-x: scroll;
+`;

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/styled.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/styled.js
@@ -7,6 +7,8 @@ export const RedButton = styled(Button)`
 `;
 
 export const Wrapper = styled.div`
+  top: 0;
+  position: absolute;
   overflow-x: hidden;
   display: flex;
   flex-direction: row;

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/index.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/index.js
@@ -10,24 +10,7 @@ const LogViewerWidget = ({
   logFileSizeField,
   logRecordExpirationField
 }) => {
-  return (
-    <>
-      id: {id}
-      <br />
-      endpoint: {endpoint}
-      <br />
-      schedulePeriod: {schedulePeriod}
-      <br />
-      logFileSizeField: {logFileSizeField}
-      <br />
-      logLinesField: {logLinesField}
-      <br />
-      logRecordExpirationField: {logRecordExpirationField}
-      <br />
-      path: {path}
-      <br />
-    </>
-  );
+  return <></>;
 };
 
 LogViewerWidget.propTypes = {

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/index.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/index.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { number, string } from 'prop-types';
-
 import Toolbar from './Toolbar';
+import LogList from './LogList';
+import { Container } from './styled';
 
 const LogViewerWidget = ({
   id,
@@ -12,7 +13,12 @@ const LogViewerWidget = ({
   logFileSizeField,
   logRecordExpirationField
 }) => {
-  return <Toolbar />;
+  return (
+    <Container>
+      <Toolbar />
+      <LogList />
+    </Container>
+  );
 };
 
 LogViewerWidget.propTypes = {

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/index.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { number, string } from 'prop-types';
 
+import Toolbar from './Toolbar';
+
 const LogViewerWidget = ({
   id,
   endpoint,
@@ -10,7 +12,7 @@ const LogViewerWidget = ({
   logFileSizeField,
   logRecordExpirationField
 }) => {
-  return <></>;
+  return <Toolbar />;
 };
 
 LogViewerWidget.propTypes = {

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/index.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/index.js
@@ -1,11 +1,51 @@
 import React from 'react';
+import { number, string } from 'prop-types';
 
-const LogViewerWidget = () => {
-  return <>TODO</>;
+const LogViewerWidget = ({
+  id,
+  endpoint,
+  schedulePeriod,
+  path,
+  logLinesField,
+  logFileSizeField,
+  logRecordExpirationField
+}) => {
+  return (
+    <>
+      id: {id}
+      <br />
+      endpoint: {endpoint}
+      <br />
+      schedulePeriod: {schedulePeriod}
+      <br />
+      logFileSizeField: {logFileSizeField}
+      <br />
+      logLinesField: {logLinesField}
+      <br />
+      logRecordExpirationField: {logRecordExpirationField}
+      <br />
+      path: {path}
+      <br />
+    </>
+  );
 };
 
-LogViewerWidget.propTypes = {};
+LogViewerWidget.propTypes = {
+  endpoint: string,
+  schedulePeriod: number,
+  path: string,
+  logLinesField: number,
+  logFileSizeField: number,
+  logRecordExpirationField: number
+};
 
-LogViewerWidget.defaultProps = {};
+LogViewerWidget.defaultProps = {
+  endpoint: '',
+  schedulePeriod: 60,
+  path: '',
+  logLinesField: 1000,
+  logFileSizeField: 50,
+  logRecordExpirationField: 5
+};
 
 export default LogViewerWidget;

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/index.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const LogViewerWidget = () => {
+  return <>TODO</>;
+};
+
+LogViewerWidget.propTypes = {};
+
+LogViewerWidget.defaultProps = {};
+
+export default LogViewerWidget;

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/styled.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/styled.js
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled/macro';
+
+export const Container = styled.div`
+  height: 100%;
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 76px 1fr;
+`;

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/styled.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/styled.js
@@ -1,9 +1,7 @@
 import styled from '@emotion/styled/macro';
 
 export const Container = styled.div`
+  position: relative;
   height: 100%;
   width: 100%;
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: 76px 1fr;
 `;

--- a/cogboard-webapp/src/theme.js
+++ b/cogboard-webapp/src/theme.js
@@ -25,6 +25,12 @@ export const theme = createMuiTheme({
         marginTop: 0,
         marginRight: 0
       }
+    },
+    // Datepicker dialog
+    MuiDialogActions: {
+      root: {
+        backgroundColor: COLORS.WHITE
+      }
     }
   },
   palette: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above (if possible start with issue number with # prefix) -->
<!--- Example: #123 - Some description -->

<!--- Remember to use appropriate Labels - this will help to group pull requests in release notes -->

## Description
<!--- Describe your changes in detail -->

Add log list layout
There is static **Level** and **Date** field. Other fields may vary depending on logs provider.
There is also `additionalData` in expanded static section.
For now, fields called **message** gets 3 times the space.

## Motivation and Context

#378 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots 
<img width="1059" alt="image" src="https://user-images.githubusercontent.com/50049833/135510367-da4fed98-7e9e-44d7-a3b6-efd9625922c1.png">

<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the [code style](https://github.com/wttech/cogboard/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] Automated functional tests have been added or modified to cover my changes (if applicable)
- [ ] I have updated the documentation accordingly.

---

I hereby agree to the terms of the Cogboard Contributor License Agreement.
