### PR TITLE
#412 - LogViewer - small patches in widget core

### DIFF
--- a/cogboard-app/src/main/kotlin/com/cognifide/cogboard/config/controller/CredentialsController.kt
+++ b/cogboard-app/src/main/kotlin/com/cognifide/cogboard/config/controller/CredentialsController.kt
@@ -37,6 +37,7 @@ class CredentialsController : AbstractVerticle() {
 
     private fun JsonObject.filterSensitiveData(): JsonObject {
         this.remove(Props.PASSWORD)
+        this.remove(Props.SSH_KEY)
         return this
     }
 

--- a/cogboard-app/src/main/kotlin/com/cognifide/cogboard/config/controller/CredentialsController.kt
+++ b/cogboard-app/src/main/kotlin/com/cognifide/cogboard/config/controller/CredentialsController.kt
@@ -38,6 +38,7 @@ class CredentialsController : AbstractVerticle() {
     private fun JsonObject.filterSensitiveData(): JsonObject {
         this.remove(Props.PASSWORD)
         this.remove(Props.SSH_KEY)
+        this.remove(Props.SSH_KEY_PASSPHRASE)
         return this
     }
 

--- a/cogboard-app/src/main/kotlin/com/cognifide/cogboard/config/model/Credential.kt
+++ b/cogboard-app/src/main/kotlin/com/cognifide/cogboard/config/model/Credential.kt
@@ -5,5 +5,6 @@ data class Credential(
     val label: String,
     val user: String,
     val password: String?,
-    val token: String?
+    val token: String?,
+    val sshKey: String?
 )

--- a/cogboard-app/src/main/kotlin/com/cognifide/cogboard/config/model/Credential.kt
+++ b/cogboard-app/src/main/kotlin/com/cognifide/cogboard/config/model/Credential.kt
@@ -6,5 +6,6 @@ data class Credential(
     val user: String,
     val password: String?,
     val token: String?,
-    val sshKey: String?
+    val sshKey: String?,
+    val sshKeyPassphrase: String?
 )

--- a/cogboard-webapp/src/components/CredentialForm/index.js
+++ b/cogboard-webapp/src/components/CredentialForm/index.js
@@ -23,7 +23,8 @@ const CredentialsForm = ({
     'PasswordField',
     'PasswordConfirmationField',
     'TokenField',
-    'SSHKeyField'
+    'SSHKeyField',
+    'SSHKeyPassphraseField'
   ];
 
   const constraints = {
@@ -84,7 +85,8 @@ CredentialsForm.defaultProps = {
   password: '',
   confirmationPassword: '',
   token: '',
-  sshKey: ''
+  sshKey: '',
+  sshKeyPassphrase: ''
 };
 
 export default CredentialsForm;

--- a/cogboard-webapp/src/components/CredentialForm/index.js
+++ b/cogboard-webapp/src/components/CredentialForm/index.js
@@ -22,7 +22,8 @@ const CredentialsForm = ({
     'UsernameField',
     'PasswordField',
     'PasswordConfirmationField',
-    'TokenField'
+    'TokenField',
+    'SSHKeyField'
   ];
 
   const constraints = {
@@ -82,7 +83,8 @@ CredentialsForm.defaultProps = {
   user: '',
   password: '',
   confirmationPassword: '',
-  token: ''
+  token: '',
+  sshKey: ''
 };
 
 export default CredentialsForm;

--- a/cogboard-webapp/src/components/widgets/dialogFields/FileTextInput.js
+++ b/cogboard-webapp/src/components/widgets/dialogFields/FileTextInput.js
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+
+import { Button, InputLabel } from '@material-ui/core';
+import { StyledValidationMessages } from '../../WidgetForm/styled';
+import {
+  DeleteButton,
+  StyledHorizontalStack,
+  StyledLabel,
+  StyledVerticalStack
+} from './styled';
+
+const FileTextInput = ({
+  error,
+  dataCy,
+  values,
+  label,
+  value,
+  onChange,
+  ...other
+}) => {
+  const [filename, setFilename] = useState('');
+
+  const getFileContents = async e => {
+    e.preventDefault();
+    const file = e.target.files[0];
+    const reader = new FileReader();
+    reader.onload = async e => {
+      const text = e.target.result;
+      let event = e;
+      event.target.value = text;
+      onChange(event);
+      alert(text);
+      console.log(text);
+    };
+    reader.readAsText(file);
+    setFilename(file.name);
+  };
+
+  const deleteFile = e => {
+    e.preventDefault();
+    setFilename('');
+    let event = e;
+    event.target.value = '';
+    onChange(event);
+  };
+
+  const fileInfo =
+    filename === '' ? null : (
+      <StyledHorizontalStack>
+        <p>{filename}</p>
+        <DeleteButton variant="contained" onClick={e => deleteFile(e)}>
+          Delete
+        </DeleteButton>
+      </StyledHorizontalStack>
+    );
+
+  return (
+    <StyledVerticalStack>
+      <StyledLabel>SSH Key</StyledLabel>
+      <StyledHorizontalStack>
+        <Button variant="contained" component="label">
+          Upload a File
+          <input type="file" hidden onChange={e => getFileContents(e)} />
+        </Button>
+        {fileInfo}
+      </StyledHorizontalStack>
+      <StyledValidationMessages messages={error} data-cy={`${dataCy}-error`} />
+    </StyledVerticalStack>
+  );
+};
+
+export default FileTextInput;

--- a/cogboard-webapp/src/components/widgets/dialogFields/FileTextInput.js
+++ b/cogboard-webapp/src/components/widgets/dialogFields/FileTextInput.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Button, InputLabel } from '@material-ui/core';
+import { Button } from '@material-ui/core';
 import { StyledValidationMessages } from '../../WidgetForm/styled';
 import {
   DeleteButton,
@@ -9,15 +9,7 @@ import {
   StyledVerticalStack
 } from './styled';
 
-const FileTextInput = ({
-  error,
-  dataCy,
-  values,
-  label,
-  value,
-  onChange,
-  ...other
-}) => {
+const FileTextInput = ({ error, dataCy, onChange }) => {
   const [filename, setFilename] = useState('');
 
   const getFileContents = async e => {
@@ -29,8 +21,6 @@ const FileTextInput = ({
       let event = e;
       event.target.value = text;
       onChange(event);
-      alert(text);
-      console.log(text);
     };
     reader.readAsText(file);
     setFilename(file.name);

--- a/cogboard-webapp/src/components/widgets/dialogFields/index.js
+++ b/cogboard-webapp/src/components/widgets/dialogFields/index.js
@@ -111,10 +111,16 @@ const dialogFields = {
           message: vm.SSH_KEY_BEGIN,
           excludeEmptyString: true
         })
-        .matches('\n-----END ([A-Z]{1,} )*PRIVATE KEY-----$', {
+        .matches('\n-----END ([A-Z]{1,} )*PRIVATE KEY-----\n$', {
           message: vm.SSH_KEY_END,
           excludeEmptyString: true
         })
+  },
+  SSHKeyPassphraseField: {
+    component: PasswordInput,
+    name: 'sshKeyPassphrase',
+    label: 'SSH Private Key Passphrase',
+    validator: () => string()
   },
   PublicURL: {
     component: TextInput,

--- a/cogboard-webapp/src/components/widgets/dialogFields/index.js
+++ b/cogboard-webapp/src/components/widgets/dialogFields/index.js
@@ -106,11 +106,11 @@ const dialogFields = {
     label: 'SSH Private Key',
     validator: () =>
       string()
-        .matches('^-----BEGIN OPENSSH PRIVATE KEY-----\n', {
+        .matches('^-----BEGIN ([A-Z]{1,} )*PRIVATE KEY-----\n', {
           message: vm.SSH_KEY_BEGIN,
           excludeEmptyString: true
         })
-        .matches('\n-----END OPENSSH PRIVATE KEY-----$', {
+        .matches('\n-----END ([A-Z]{1,} )*PRIVATE KEY-----$', {
           message: vm.SSH_KEY_END,
           excludeEmptyString: true
         })

--- a/cogboard-webapp/src/components/widgets/dialogFields/index.js
+++ b/cogboard-webapp/src/components/widgets/dialogFields/index.js
@@ -100,6 +100,21 @@ const dialogFields = {
     label: 'Token',
     validator: () => string()
   },
+  SSHKeyField: {
+    component: MultilineTextInput,
+    name: 'sshKey',
+    label: 'SSH Private Key',
+    validator: () =>
+      string()
+        .matches('^-----BEGIN OPENSSH PRIVATE KEY-----\n', {
+          message: vm.SSH_KEY_BEGIN,
+          excludeEmptyString: true
+        })
+        .matches('\n-----END OPENSSH PRIVATE KEY-----$', {
+          message: vm.SSH_KEY_END,
+          excludeEmptyString: true
+        })
+  },
   PublicURL: {
     component: TextInput,
     name: 'publicUrl',

--- a/cogboard-webapp/src/components/widgets/dialogFields/index.js
+++ b/cogboard-webapp/src/components/widgets/dialogFields/index.js
@@ -105,7 +105,7 @@ const dialogFields = {
     name: 'publicUrl',
     label: 'Public URL',
     validator: () =>
-      string().matches(/^(http|https|ws|ftp):\/\/.*([:.]).*/, {
+      string().matches(/^(http|https|ws|ftp|ssh):\/\/.*([:.]).*/, {
         message: vm.INVALID_PUBLIC_URL(),
         excludeEmptyString: true
       })
@@ -251,7 +251,7 @@ const dialogFields = {
     name: 'url',
     label: 'URL',
     validator: () =>
-      string().matches(/^(http|https|ws|ftp):\/\/.*([:.]).*/, {
+      string().matches(/^(http|https|ws|ftp|ssh):\/\/.*([:.]).*/, {
         message: vm.INVALID_URL(),
         excludeEmptyString: true
       })

--- a/cogboard-webapp/src/components/widgets/dialogFields/index.js
+++ b/cogboard-webapp/src/components/widgets/dialogFields/index.js
@@ -37,6 +37,7 @@ import RangeSlider from './RangeSlider';
 import LinkListInput from './LinkListInput';
 import ToDoListInput from './ToDoListinput';
 import WidgetTypeField from './WidgetTypeField';
+import FileTextInput from './FileTextInput';
 
 const dialogFields = {
   LabelField: {
@@ -101,7 +102,7 @@ const dialogFields = {
     validator: () => string()
   },
   SSHKeyField: {
-    component: MultilineTextInput,
+    component: FileTextInput,
     name: 'sshKey',
     label: 'SSH Private Key',
     validator: () =>

--- a/cogboard-webapp/src/components/widgets/dialogFields/styled.js
+++ b/cogboard-webapp/src/components/widgets/dialogFields/styled.js
@@ -2,7 +2,7 @@ import styled from '@emotion/styled/macro';
 import NumberInput from './NumberInput';
 import IntegerInput from './IntegerInput';
 import { COLORS } from '../../../constants';
-import { Box, Input, Fab, List, FormControl } from '@material-ui/core';
+import { Box, Input, Fab, List, FormControl, Button } from '@material-ui/core';
 
 export const StyledNumberInput = styled(NumberInput)`
   flex-basis: calc(50% - 18px);
@@ -150,5 +150,36 @@ export const StyledMultiLineWrapper = styled.div`
 
   .MuiTextField-root {
     flex: 1 0 auto;
+  }
+`;
+
+export const StyledHorizontalStack = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+`;
+
+export const StyledVerticalStack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+export const StyledLabel = styled.p`
+  font-size: 1rem;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.7);
+  transform: translate(0, 1.5px) scale(0.75);
+  transform-origin: top left;
+  font-weight: 400;
+  line-height: 1;
+  letter-spacing: 0.00938em;
+`;
+
+export const DeleteButton = styled(Button)`
+  background-color: ${COLORS.RED};
+
+  &:hover {
+    background-color: ${COLORS.DARK_RED};
   }
 `;

--- a/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/FilterPicker/index.js
+++ b/cogboard-webapp/src/components/widgets/types/LogViewerWidget/Toolbar/FilterPicker/index.js
@@ -17,7 +17,7 @@ const FilterPicker = () => {
   };
 
   const [filters, setFilters] = useState([]);
-  const [logLevel, setLogLevel] = useState('');
+  const [logLevel, setLogLevel] = useState('info');
 
   return (
     <ToolbarGroup title="Filters">
@@ -48,7 +48,6 @@ const FilterPicker = () => {
             </ScrollableBox>
           )}
         >
-          <MenuItem value="all">ALL</MenuItem>
           <MenuItem value="debug">DEBUG</MenuItem>
           <MenuItem value="info">INFO</MenuItem>
           <MenuItem value="warn">WARN</MenuItem>
@@ -65,7 +64,6 @@ const FilterPicker = () => {
           value={logLevel}
           onChange={e => setLogLevel(e.target.value)}
         >
-          <MenuItem value="">ALL</MenuItem>
           <MenuItem value="debug">DEBUG</MenuItem>
           <MenuItem value="info">INFO</MenuItem>
           <MenuItem value="warn">WARN</MenuItem>

--- a/cogboard-webapp/src/constants/index.js
+++ b/cogboard-webapp/src/constants/index.js
@@ -306,9 +306,8 @@ export const validationMessages = {
   FIELD_MIN_ITEMS: () => 'This field must have at least 1 item.',
   UNIQUE_FIELD: () => 'This field must be unique.',
   PASSWORD_MATCH: () => 'Password must match.',
-  SSH_KEY_BEGIN: () =>
-    'The key must begin with "-----BEGIN OPENSSH PRIVATE KEY-----"',
-  SSH_KEY_END: () => 'The key must end with "-----END OPENSSH PRIVATE KEY-----"'
+  SSH_KEY_BEGIN: () => 'The key must begin with "-----BEGIN PRIVATE KEY-----"',
+  SSH_KEY_END: () => 'The key must end with "-----END PRIVATE KEY-----"'
 };
 
 export const NOTIFICATIONS = {

--- a/cogboard-webapp/src/constants/index.js
+++ b/cogboard-webapp/src/constants/index.js
@@ -305,7 +305,10 @@ export const validationMessages = {
   INVALID_PUBLIC_URL: () => 'Invalid Public URL',
   FIELD_MIN_ITEMS: () => 'This field must have at least 1 item.',
   UNIQUE_FIELD: () => 'This field must be unique.',
-  PASSWORD_MATCH: () => 'Password must match.'
+  PASSWORD_MATCH: () => 'Password must match.',
+  SSH_KEY_BEGIN: () =>
+    'The key must begin with "-----BEGIN OPENSSH PRIVATE KEY-----"',
+  SSH_KEY_END: () => 'The key must end with "-----END OPENSSH PRIVATE KEY-----"'
 };
 
 export const NOTIFICATIONS = {

--- a/functional/cypress-tests/cypress/fixtures/credentialsEndpoints.js
+++ b/functional/cypress-tests/cypress/fixtures/credentialsEndpoints.js
@@ -4,7 +4,8 @@ export const badCredentials = () => {
     password: 'xxxxxxxxxxx',
     passwordConf: 'zzz',
     user: 'xxxxxxxxxxxxxxxxxxxxxxxxxx',
-    label: ' '
+    label: ' ',
+    sshKey: 'xxx',
   };
 };
 

--- a/functional/cypress-tests/cypress/fixtures/credentialsEndpoints.js
+++ b/functional/cypress-tests/cypress/fixtures/credentialsEndpoints.js
@@ -6,6 +6,7 @@ export const badCredentials = () => {
     user: 'xxxxxxxxxxxxxxxxxxxxxxxxxx',
     label: ' ',
     sshKey: 'xxx',
+    sshKeyPassphrase: ''
   };
 };
 

--- a/functional/cypress-tests/cypress/integration/credentials.js
+++ b/functional/cypress-tests/cypress/integration/credentials.js
@@ -35,11 +35,11 @@ describe('Credentials', () => {
         'credential-form-auth-user-input-error'
       )
       .assertErrorMessageVisible(
-        'The key must begin with "-----BEGIN OPENSSH PRIVATE KEY-----"',
+        'The key must begin with "-----BEGIN PRIVATE KEY-----"',
         'credential-form-auth-ssh-key-input-error'
       )
       .assertErrorMessageVisible(
-        'The key must end with "-----END OPENSSH PRIVATE KEY-----"',
+        'The key must end with "-----END PRIVATE KEY-----"',
         'credential-form-auth-ssh-key-input-error'
       );
   });

--- a/functional/cypress-tests/cypress/integration/credentials.js
+++ b/functional/cypress-tests/cypress/integration/credentials.js
@@ -25,6 +25,7 @@ describe('Credentials', () => {
       .applyPassword()
       .assertErrorMessageVisible('Password must match.', 'credential-form-auth')
       .applyToken()
+      .applySSHKey()
       .assertErrorMessageVisible(
         'This field is required',
         'credential-form-auth-label-input-error'
@@ -32,6 +33,14 @@ describe('Credentials', () => {
       .assertErrorMessageVisible(
         'Label length must be less or equal to 25.',
         'credential-form-auth-user-input-error'
+      )
+      .assertErrorMessageVisible(
+        'The key must begin with "-----BEGIN OPENSSH PRIVATE KEY-----"',
+        'credential-form-auth-ssh-key-input-error'
+      )
+      .assertErrorMessageVisible(
+        'The key must end with "-----END OPENSSH PRIVATE KEY-----"',
+        'credential-form-auth-ssh-key-input-error'
       );
   });
 

--- a/functional/cypress-tests/cypress/support/credential.js
+++ b/functional/cypress-tests/cypress/support/credential.js
@@ -69,6 +69,17 @@ class Credentials {
     return this;
   }
 
+  applySSHKeyPassphrase(config) {
+    if (config !== undefined) {
+      this.config = config;
+    }
+    cy.get('[data-cy="credential-form-auth-ssh-key-passphrase-input"]')
+      .clear()
+      .type(this.config.sshKeyPassphrase)
+      .blur();
+    return this;
+  }
+
   save() {
     cy.get('[data-cy="credential-form-submit-button"]').click();
     return this;
@@ -88,8 +99,7 @@ class Credentials {
   }
 
   assertErrorMessageVisible(message, dataCYName) {
-    cy
-      .contains(`[data-cy^="${dataCYName}"]`, message)
+    cy.contains(`[data-cy^="${dataCYName}"]`, message)
       .scrollIntoView()
       .should('is.visible');
     return this;

--- a/functional/cypress-tests/cypress/support/credential.js
+++ b/functional/cypress-tests/cypress/support/credential.js
@@ -58,6 +58,17 @@ class Credentials {
     return this;
   }
 
+  applySSHKey(config) {
+    if (config !== undefined) {
+      this.config = config;
+    }
+    cy.get('[data-cy="credential-form-auth-ssh-key-input"]')
+      .clear()
+      .type(this.config.sshKey)
+      .blur();
+    return this;
+  }
+
   save() {
     cy.get('[data-cy="credential-form-submit-button"]').click();
     return this;
@@ -77,7 +88,10 @@ class Credentials {
   }
 
   assertErrorMessageVisible(message, dataCYName) {
-    cy.contains(`[data-cy^="${dataCYName}"]`, message).should('is.visible');
+    cy
+      .contains(`[data-cy^="${dataCYName}"]`, message)
+      .scrollIntoView()
+      .should('is.visible');
     return this;
   }
 }


### PR DESCRIPTION
## Description

Modified the widget:
- removed `ALL` from the list of possible log levels
- the configuration is not deleted during redeployment
- added the ability to enter the SSH private key when adding or editing a credential
- added the ability to enter the URL starting with `ssh://` when adding or editing an endpoint

## Motivation and Context
#412

## Screenshots

![Zrzut ekranu 2021-10-24 o 18 16 37](https://user-images.githubusercontent.com/31923361/138602943-28431096-e169-46eb-b59a-29239b9b69ee.png)

![Zrzut ekranu 2021-10-24 o 18 17 11](https://user-images.githubusercontent.com/31923361/138602947-a996e3f5-d53e-46bc-8cb1-e8d2ad43c86a.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the [code style](https://github.com/wttech/cogboard/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] Automated functional tests have been added or modified to cover my changes (if applicable)
- [ ] I have updated the documentation accordingly.

---

I hereby agree to the terms of the Cogboard Contributor License Agreement.
