### PR TITLE
LogViewer: Change labels, enhance credentials file input

### DIFF
--- a/cogboard-webapp/src/components/widgets/dialogFields/FileTextInput.js
+++ b/cogboard-webapp/src/components/widgets/dialogFields/FileTextInput.js
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 
-import { Button } from '@material-ui/core';
+import { Button, IconButton, Tooltip } from '@material-ui/core';
+import { Delete } from '@material-ui/icons';
 import { StyledValidationMessages } from '../../WidgetForm/styled';
 import {
-  DeleteButton,
   StyledHorizontalStack,
   StyledLabel,
   StyledVerticalStack
@@ -11,48 +11,58 @@ import {
 
 const FileTextInput = ({ error, dataCy, onChange }) => {
   const [filename, setFilename] = useState('');
+  const inputRef = useRef(null);
 
   const getFileContents = async event => {
     event.preventDefault();
     const file = event.target.files[0];
-    const reader = new FileReader();
-    reader.onload = async event => {
-      const text = event.target.result;
-      event.target.value = text;
-      onChange(event);
-    };
-    reader.readAsText(file);
-    setFilename(file.name);
+
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = async event => {
+        const text = event.target.result;
+        event.target.value = text;
+        onChange(event);
+      };
+      reader.readAsText(file);
+      setFilename(file.name);
+    }
   };
 
   const deleteFile = event => {
     event.preventDefault();
+    inputRef.current.value = null;
     setFilename('');
     event.target.value = '';
     onChange(event);
   };
 
-  const fileInfo =
-    filename === '' ? null : (
-      <StyledHorizontalStack>
-        <p>{filename}</p>
-        <DeleteButton variant="contained" onClick={e => deleteFile(e)}>
-          Delete
-        </DeleteButton>
-      </StyledHorizontalStack>
-    );
-
   return (
     <StyledVerticalStack>
-      <StyledLabel>SSH Key</StyledLabel>
+      <StyledLabel>SSH private key</StyledLabel>
       <StyledHorizontalStack>
         <Button variant="contained" component="label">
-          Upload a File
-          <input type="file" hidden onChange={e => getFileContents(e)} />
+          {filename || `Upload a File`}
+          <input
+            ref={inputRef}
+            type="file"
+            hidden
+            onChange={e => getFileContents(e)}
+          />
         </Button>
-        {fileInfo}
+        {filename && (
+          <Tooltip title="Delete" placement="bottom">
+            <IconButton onClick={e => deleteFile(e)}>
+              <Delete />
+            </IconButton>
+          </Tooltip>
+        )}
       </StyledHorizontalStack>
-      <StyledValidationMessages messages={error} data-cy={`${dataCy}-error`} />
+      <StyledValidationMessages
+        className={'Mui-error MuiFormHelperText-root'}
+        messages={error}
+        data-cy={`${dataCy}-error`}
+      />
     </StyledVerticalStack>
   );
 };

--- a/cogboard-webapp/src/components/widgets/dialogFields/index.js
+++ b/cogboard-webapp/src/components/widgets/dialogFields/index.js
@@ -119,7 +119,7 @@ const dialogFields = {
   SSHKeyPassphraseField: {
     component: PasswordInput,
     name: 'sshKeyPassphrase',
-    label: 'SSH Private Key Passphrase',
+    label: 'SSH private key passphrase',
     validator: () => string()
   },
   PublicURL: {
@@ -590,7 +590,7 @@ const dialogFields = {
   LogLinesField: {
     component: NumberInput,
     name: 'logLinesField',
-    label: 'Number of lines to return',
+    label: 'Maximum number of lines to return',
     initialValue: 1000,
     min: 1,
     step: 1,

--- a/cogboard-webapp/src/components/widgets/dialogFields/styled.js
+++ b/cogboard-webapp/src/components/widgets/dialogFields/styled.js
@@ -156,13 +156,15 @@ export const StyledMultiLineWrapper = styled.div`
 export const StyledHorizontalStack = styled.div`
   display: flex;
   flex-direction: row;
+  align-items: center;
   gap: 12px;
 `;
 
 export const StyledVerticalStack = styled.div`
+  margin: 16px 0 8px 0;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 6px;
 `;
 
 export const StyledLabel = styled.p`


### PR DESCRIPTION
Change dialog fields labels(credentials and LogViewer edit dialog).
Fix error, when closing input file dialog without file.
Fix error, when choosing the same file again.
Enhance file input styles.


